### PR TITLE
docs: Update project name to Morthy and add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2024 The Morthy Project Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+“Software”), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Audiobook Generator
+# Morthy - Audiobook Generator
 
-A command-line tool to convert book files (currently EPUB and PDF) into MP3 audiobooks using Text-to-Speech (TTS).
+Morthy is a command-line tool to convert book files (currently EPUB and PDF) into MP3 audiobooks using Text-to-Speech (TTS).
 
 ## Features
 

--- a/parser.py
+++ b/parser.py
@@ -6,7 +6,6 @@ This module provides functions to extract plain text from EPUB, PDF, and
 type, including error handling for common issues like file not found or
 corrupted files.
 """
-
 import ebooklib
 from ebooklib import epub
 from bs4 import BeautifulSoup

--- a/tts.py
+++ b/tts.py
@@ -5,7 +5,6 @@ This module uses the gTTS (Google Text-to-Speech) library to convert
 a given text string into an MP3 audio file. It includes error handling
 for common TTS-related issues.
 """
-
 from gtts import gTTS, gTTSError
 import os
 


### PR DESCRIPTION
- Updated README.md to reflect the project name "Morthy".
- Reviewed and confirmed clarity of the usage guide in README.md.
- Added a LICENSE file with the standard MIT License text. (Year: 2024, Copyright Holder: The Morthy Project Contributors)