### PR TITLE
feat: Implement FB2 to text conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Morthy is a command-line tool to convert book files (currently EPUB and PDF) int
 
 ## Features
 
-*   Supports EPUB (.epub) and PDF (.pdf) file formats.
+*   Supports EPUB (.epub), PDF (.pdf), and FB2 (.fb2) file formats.
 *   Converts extracted text to speech using Google Text-to-Speech (gTTS).
 *   Allows specifying output MP3 filename.
 *   Allows specifying the language for TTS.
@@ -19,8 +19,9 @@ The following Python libraries are required:
 *   `PyPDF2>=3.0.1` (for PDF parsing)
 *   `gTTS>=2.5.4` (for Text-to-Speech)
 *   `BeautifulSoup4>=4.13.4` (for HTML processing in EPUBs)
-*   `lxml>=5.4.0` (XML processing, often a dependency for EbookLib)
+*   `lxml>=5.4.0` (for XML processing, including FB2 parsing)
 *   `reportlab>=4.4.1` (for creating sample PDFs in the test suite)
+*   `FB2==0.2.1` (listed in requirements, though current FB2 parsing relies on lxml)
 
 ## Installation
 
@@ -43,7 +44,7 @@ python main.py <input_file> [--output_file <output_name.mp3>] [--lang <language_
 
 **Arguments:**
 
-*   `input_file`: (Required) Path to the input book file. Supported formats: `.epub`, `.pdf`.
+*   `input_file`: (Required) Path to the input book file. Supported formats: `.epub`, `.pdf`, `.fb2`.
 *   `--output_file`: (Optional) Desired name for the output MP3 file. If not provided, it defaults to the input file name with an `.mp3` extension (e.g., `mybook.epub` becomes `mybook.mp3`).
 *   `--lang`: (Optional) Language code for the text-to-speech conversion (e.g., 'en' for English, 'es' for Spanish). Defaults to 'en'.
 
@@ -60,12 +61,17 @@ python main.py <input_file> [--output_file <output_name.mp3>] [--lang <language_
     python main.py "My Document.pdf" --output_file "audio_doc.mp3" --lang es
     ```
 
+3.  **Convert an FB2 file with default settings:**
+    ```bash
+    python main.py "story.fb2"
+    ```
+    *(Output will be `story.mp3`)*
+
 **Supported Formats:**
 
 *   EPUB (.epub)
 *   PDF (.pdf)
-
-*Note: FB2 (.fb2) support was initially planned and has partial implementation in `parser.py` but is currently non-functional due to unresolved library import issues for the `fb2` package. It is considered a feature for future improvement.*
+*   FB2 (.fb2) - Parsed using `lxml`.
 
 ## Error Handling
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ PyPDF2==3.0.1
 gTTS==2.5.4
 BeautifulSoup4==4.13.4
 lxml==5.4.0
+FB2==0.2.1 # Required by the project, though not directly used in FB2 parsing logic now
 # For test suite (creating sample PDFs)
 reportlab==4.4.1

--- a/test_fb2_import.py
+++ b/test_fb2_import.py
@@ -1,22 +1,50 @@
+import sys
+print(f"Python sys.path: {sys.path}")
+
 try:
     from fb2.fb2 import FB2Tree
     print("Successfully imported FB2Tree from fb2.fb2")
 except ImportError as e:
     print(f"Failed to import FB2Tree from fb2.fb2: {e}")
-    try:
-        import fb2
-        print("Successfully imported fb2 directly")
-        # If fb2 imports, check if FB2Tree is an attribute or how to access it
-        if hasattr(fb2, 'FB2Tree'):
-            print("FB2Tree is available under fb2.FB2Tree")
-        elif hasattr(fb2, 'fb2') and hasattr(fb2.fb2, 'FB2Tree'):
-            print("FB2Tree is available under fb2.fb2.FB2Tree")
-        else:
-            print("fb2 module imported, but FB2Tree not found directly. Further inspection needed.")
-            # Attempt to list attributes of the fb2 module
-            print(f"Attributes of fb2 module: {dir(fb2)}")
-            if hasattr(fb2, 'fb2'):
-                print(f"Attributes of fb2.fb2 module: {dir(fb2.fb2)}")
 
-    except ImportError as ie:
-        print(f"Failed to import fb2 directly: {ie}")
+# It's possible FB2Tree is part of lxml, as lxml is a dependency for FB2 processing
+try:
+    from lxml import etree
+    # Attempt to parse a dummy FB2 string to see if lxml handles it
+    # This is a common way to check if lxml can handle FB2-like structures
+    # A real FB2 file would have a more complex structure.
+    fb2_minimal_content = """
+    <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">
+      <description>
+        <title-info>
+          <genre>antica</genre>
+          <author><first-name>John</first-name><last-name>Doe</last-name></author>
+          <book-title>Test Book</book-title>
+          <lang>en</lang>
+        </title-info>
+        <document-info>
+          <author><nickname>PyTest</nickname></author>
+          <date>2024-05-07</date>
+          <version>1.0</version>
+        </document-info>
+      </description>
+    </FictionBook>
+    """
+    tree = etree.fromstring(fb2_minimal_content.encode('utf-8'))
+    if tree.tag == '{http://www.gribuser.ru/xml/fictionbook/2.0}FictionBook':
+        print("Successfully parsed dummy FB2 XML with lxml.etree and found FictionBook tag")
+        # Further checks could involve looking for FB2Tree or similar classes if lxml wraps them
+        # For now, confirming lxml can parse FB2 structure is a good step.
+    else:
+        print(f"lxml.etree parsed XML, but root tag is not FictionBook: {tree.tag}")
+
+except ImportError as e:
+    print(f"Failed to import etree from lxml: {e}")
+except Exception as e:
+    print(f"An error occurred while trying to parse FB2 with lxml: {e}")
+
+try:
+    import fb2
+    print("Successfully imported fb2 directly")
+except ImportError as e:
+    print(f"Failed to import fb2 directly: {e}")


### PR DESCRIPTION
This commit finalizes the implementation for converting books in FB2 format to plain text.

Key changes:
- Updated `parser.py`:
    - The `extract_text_from_fb2` function now uses `lxml.etree` for robust XML parsing.
    - Text extraction specifically targets the content within the `<body>` tag using XPath.
    - Improved whitespace normalization for the extracted text.
    - Removed dependency on the non-functional `fb2` library for parsing.
- Added `FB2==0.2.1` to `requirements.txt` for completeness, although `lxml` is used for parsing.
- Added comprehensive unit tests in `tests/test_parser.py` for `extract_text_from_fb2`, covering various scenarios including valid files, malformed XML, missing/empty body tags, and non-FB2 files.
- Verified that `main.py` correctly handles FB2 files and integrates the updated parser.
- Updated `README.md` and internal documentation in `parser.py` to reflect full FB2 support.