### PR TITLE
feat: Add web interface for book uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ python main.py <input_file> [--output_file <output_name.mp3>] [--lang <language_
     python main.py "My Document.pdf" --output_file "audio_doc.mp3" --lang es
     ```
 
+## Running the Web Application
+
+This project also includes a web interface for converting books to audiobooks.
+
+1.  **Install Dependencies:**
+    Ensure all dependencies, including Flask (which is now part of `requirements.txt`), are installed:
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+2.  **Run the Web Application:**
+    Navigate to the project's root directory and run:
+    ```bash
+    python web_app.py
+    ```
+
+3.  **Access the Application:**
+    Open your web browser and go to:
+    ```
+    http://127.0.0.1:5000/
+    ```
+
+You can then upload your book files (supported formats: EPUB, PDF, FB2) through the web interface to convert them into audio.
+
 **Supported Formats:**
 
 *   EPUB (.epub)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ BeautifulSoup4==4.13.4
 lxml==5.4.0
 # For test suite (creating sample PDFs)
 reportlab==4.4.1
+Flask
+# For testing
+pytest

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<title>Upload new File</title>
+<h1>Upload new File</h1>
+<form method=post enctype=multipart/form-data action="{{ url_for('upload_file') }}">
+  <input type=file name=file>
+  <input type=submit value="Upload and Convert">
+</form>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<title>Conversion Result</title>
+<body>
+    {% if success %}
+        <h1>Audiobook generated successfully!</h1>
+        <p><a href="{{ url_for('download_file', filename=filename) }}">Download MP3</a></p>
+    {% else %}
+        <h1>Error</h1>
+        <p>{{ error_message }}</p>
+    {% endif %}
+    <p><a href="{{ url_for('upload_page') }}">Upload another file</a></p>
+</body>

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,49 @@
+import pytest
+import os
+from io import BytesIO
+# Add the parent directory to sys.path to allow imports from web_app
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from web_app import app as flask_app
+
+@pytest.fixture
+def client():
+    flask_app.config['TESTING'] = True
+    # Set UPLOAD_FOLDER and GENERATED_AUDIO_FOLDER to temporary locations for testing
+    # This is important if your app writes files during tests, though these specific tests might not.
+    flask_app.config['UPLOAD_FOLDER'] = 'test_uploads'
+    flask_app.config['GENERATED_AUDIO_FOLDER'] = 'test_generated_audio'
+    
+    # Create test directories if they don't exist
+    if not os.path.exists(flask_app.config['UPLOAD_FOLDER']):
+        os.makedirs(flask_app.config['UPLOAD_FOLDER'])
+    if not os.path.exists(flask_app.config['GENERATED_AUDIO_FOLDER']):
+        os.makedirs(flask_app.config['GENERATED_AUDIO_FOLDER'])
+
+    with flask_app.test_client() as client:
+        yield client
+    
+    # Clean up test directories after tests (optional, depending on needs)
+    # import shutil
+    # shutil.rmtree(flask_app.config['UPLOAD_FOLDER'], ignore_errors=True)
+    # shutil.rmtree(flask_app.config['GENERATED_AUDIO_FOLDER'], ignore_errors=True)
+
+
+def test_index_page_loads(client):
+    """Test that the index page loads correctly."""
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b"Upload new File" in response.data
+    assert b"Upload and Convert" in response.data
+
+def test_upload_unsupported_file_type(client):
+    """Test uploading an unsupported file type."""
+    data = {
+        'file': (BytesIO(b"this is a test file content"), 'test.txt')
+    }
+    response = client.post('/upload', data=data, content_type='multipart/form-data', follow_redirects=True)
+    
+    assert response.status_code == 200 # After following redirect to result page
+    assert b"Error" in response.data # General error heading
+    assert b"Unsupported file type: '.txt'." in response.data
+    assert b"Upload another file" in response.data

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,91 @@
+import os
+from flask import Flask, render_template, request, send_from_directory, redirect, url_for
+from werkzeug.utils import secure_filename
+from parser import extract_text_from_epub, extract_text_from_pdf, extract_text_from_fb2
+from tts import convert_text_to_speech
+
+app = Flask(__name__)
+
+UPLOAD_FOLDER = 'uploads'
+GENERATED_AUDIO_FOLDER = 'generated_audio'
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+app.config['GENERATED_AUDIO_FOLDER'] = GENERATED_AUDIO_FOLDER
+
+# Create directories if they don't exist
+if not os.path.exists(UPLOAD_FOLDER):
+    os.makedirs(UPLOAD_FOLDER)
+if not os.path.exists(GENERATED_AUDIO_FOLDER):
+    os.makedirs(GENERATED_AUDIO_FOLDER)
+
+ALLOWED_EXTENSIONS = {'epub', 'pdf', 'fb2'}
+
+def allowed_file(filename):
+    return '.' in filename and \
+           filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+@app.route('/', endpoint='upload_page')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload_file():
+    if 'file' not in request.files:
+        return redirect(url_for('show_result', success=False, error_message="No file part"))
+    file = request.files['file']
+    if file.filename == '':
+        return redirect(url_for('show_result', success=False, error_message="No selected file"))
+    if file and allowed_file(file.filename):
+        filename = secure_filename(file.filename)
+        input_filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        file.save(input_filepath)
+
+        file_ext = filename.rsplit('.', 1)[1].lower()
+        extracted_text = None
+        error_message = None # Initialize error_message
+
+        if file_ext == 'epub':
+            extracted_text = extract_text_from_epub(input_filepath)
+        elif file_ext == 'pdf':
+            extracted_text = extract_text_from_pdf(input_filepath)
+        elif file_ext == 'fb2':
+            extracted_text = extract_text_from_fb2(input_filepath)
+        
+        if not extracted_text or extracted_text.strip() == "" or extracted_text.startswith("Error:"):
+            if extracted_text and extracted_text.startswith("Error:"):
+                 error_message = extracted_text # Use the specific error from parser
+            elif not extracted_text or extracted_text.strip() == "":
+                 error_message = "No text content found in the uploaded file."
+            else:
+                 error_message = "Error during text extraction."
+            return redirect(url_for('show_result', success=False, error_message=error_message))
+
+        output_filename = filename.rsplit('.', 1)[0] + '.mp3'
+        output_filepath = os.path.join(app.config['GENERATED_AUDIO_FOLDER'], output_filename)
+        
+        # Assuming convert_text_to_speech returns True on success, False on failure
+        # and potentially logs errors or returns an error message.
+        # For now, we'll stick to a generic TTS error if it returns False.
+        success_tts = convert_text_to_speech(extracted_text, output_filepath, lang='en')
+        if success_tts:
+            return redirect(url_for('show_result', success=True, filename=output_filename))
+        else:
+            error_message = "Error during text-to-speech conversion. Please ensure the text is valid and try again."
+            return redirect(url_for('show_result', success=False, error_message=error_message))
+    else:
+        file_ext_provided = file.filename.rsplit('.', 1)[1].lower() if '.' in file.filename else "none"
+        error_message = f"Unsupported file type: '.{file_ext_provided}'. Supported types are EPUB, PDF, and FB2."
+        return redirect(url_for('show_result', success=False, error_message=error_message))
+
+@app.route('/result')
+def show_result():
+    success = request.args.get('success') == 'True'
+    filename = request.args.get('filename')
+    error_message = request.args.get('error_message')
+    return render_template('result.html', success=success, filename=filename, error_message=error_message)
+
+@app.route('/download/<filename>')
+def download_file(filename):
+    return send_from_directory(app.config['GENERATED_AUDIO_FOLDER'], filename, as_attachment=True)
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
This commit introduces a Flask-based web interface that allows you to upload book files (EPUB, PDF, FB2) and convert them into MP3 audiobooks.

Key changes:
- Added Flask as a dependency.
- Created `web_app.py` containing the Flask application logic.
- Implemented HTML templates for the upload form (`index.html`) and result page (`result.html`).
- The web app supports uploading EPUB, PDF, and FB2 files.
- Uploaded files are processed using the existing `parser.py` and `tts.py` modules.
- Generated MP3 files are made available for download.
- Added error handling for various scenarios like unsupported file types, parsing errors, and TTS errors.
- Updated `README.md` with instructions on how to run the web application.
- Added basic pytest tests for the web application, covering the index page and handling of unsupported file types.